### PR TITLE
Fix #27 PlatformIO OTA upload target

### DIFF
--- a/software/extra_script.py
+++ b/software/extra_script.py
@@ -9,7 +9,10 @@ env.AddCustomTarget(
 )
 
 env.AddCustomTarget(
-    "ota",
-    "$BUILD_DIR/${PROGNAME}.elf",
-    "ota_script --firmware-path $SOURCE"
+    name="ota",
+    dependencies="$BUILD_DIR/${PROGNAME}.elf",
+    actions=["$PROJECT_DIR/ota-flasher.sh $PROJECT_DIR $PIOENV $PROGRAM_ARGS"],
+    title="OTA upload",
+    description="over the air upload / reflash (set OTA-IP-ADDRESS via pio option [-a 10.0.0.1])"
 )
+

--- a/software/ota-flasher.sh
+++ b/software/ota-flasher.sh
@@ -26,6 +26,7 @@ then
         curl -vv --show-error --fail --data-binary "@${FIRMWARE}" "http://${HOST}/flash_firmware"
     else
         echo "There is no ${WARPTYPE} WARP at ${HOST}, skip OTA flashing \"${FIRMWARE}\""
+        exit 1
     fi
 else
     echo "No firmware to flash found in dir \"${PROJECT_DIR}\""

--- a/software/warpAC011K.ini
+++ b/software/warpAC011K.ini
@@ -31,9 +31,6 @@ extra_scripts =
        extra_script.py
        post:merge_firmware_hook.py
 
-upload_protocol = custom
-upload_command = $PROJECT_DIR/ota-flasher.sh $PROJECT_DIR $PIOENV
-
 custom_backend_modules = AC011K Hardware
                          Watchdog
                          Uptime Tracker
@@ -109,6 +106,11 @@ custom_firmware_url = https://github.com/warp-more-hardware/esp32-firmware/wiki/
 custom_require_firmware_info = 0
 
 board_build.partitions = default_4MB_coredump.csv
+
+extra_scripts =
+       pre:pio_hooks.py
+       extra_script.py
+       post:merge_firmware_hook.py
 
 custom_backend_modules = AC011K Hardware
                          Watchdog


### PR DESCRIPTION
- you can now build and upload via `pio run -e warpAC011K -a 192.168.0.123 -t ota`
- and you can upload without building via `pio run -e warpAC011K -t uploadnobuild`