### PR TITLE
Fix #27 PlatformIO OTA upload target #2

### DIFF
--- a/software/extra_script.py
+++ b/software/extra_script.py
@@ -1,17 +1,21 @@
 Import("env")
 
 env.AddCustomTarget(
-    "uploadnobuild",
-    None,
-    'pio run -e %s -t nobuild -t upload' %
-        env["PIOENV"],
-    title="Uploads without building"
+    name="uploadnobuild",
+    dependencies=None,
+    actions=[
+        "pio run -e $PIOENV -t nobuild -t upload",
+    ],
+    title="Uploads without building via serial"
 )
 
 env.AddCustomTarget(
     name="ota",
     dependencies="$BUILD_DIR/${PROGNAME}.elf",
-    actions=["$PROJECT_DIR/ota-flasher.sh $PROJECT_DIR $PIOENV $PROGRAM_ARGS"],
+    actions=[
+        "pio run -e $PIOENV",
+        "$PROJECT_DIR/ota-flasher.sh $PROJECT_DIR $BUILD_DIR $PROGRAM_ARGS",
+    ],
     title="OTA upload",
     description="over the air upload / reflash (set OTA-IP-ADDRESS via pio option [-a 10.0.0.1])"
 )

--- a/software/ota-flasher.sh
+++ b/software/ota-flasher.sh
@@ -4,7 +4,7 @@
 #
 # Parameters to the script are:
 #   1: PROJECT_DIR (defaults to the current working dir)
-#   2: PIOENV      (defaults to warpAC011K)
+#   2: BUILD_DIR   (defaults to .pio/build/warp${WARPTYPE})
 #   3: HOST        (defaults to 10.0.0.1 [the default WIFI IP in the WARP software])
 #
 # Parameters can be omitted from the last to the first, but not the other way around.
@@ -13,13 +13,13 @@ WARPTYPE="AC011K"
 PWD="$(pwd)"
 
 PROJECT_DIR="${1:-$PWD}"
-PIOENV="${2:-warp${WARPTYPE}}"
+BUILD_DIR="${2:-.pio/build/warp${WARPTYPE}}"
 HOST="${3:-10.0.0.1}"
 
-FIRMWARE=$(ls -1art ${PROJECT_DIR}/build/${PIOENV}*merged* | tail -1)
+FIRMWARE=${PROJECT_DIR}/build/$(cat $BUILD_DIR/firmware_basename)_merged.bin
 INFO=$(curl -s --connect-timeout 2 "http://${HOST}/info/name")
 
-if [ -n "$FIRMWARE" ]
+if [ -f "$FIRMWARE" ]
 then
     if [[ "$INFO" == *"${WARPTYPE}"* ]]; then
         echo -e "\nflashing\n\t${INFO}\n@ ${HOST} with\n\t${FIRMWARE}\n"
@@ -29,6 +29,6 @@ then
         exit 1
     fi
 else
-    echo "No firmware to flash found in dir \"${PROJECT_DIR}\""
+    echo "No firmware to flash found: \"${FIRMWARE}\""
     exit 1
 fi

--- a/software/warpAC011K.ini
+++ b/software/warpAC011K.ini
@@ -28,8 +28,8 @@ board_build.partitions = default_8MB_coredump.csv
 
 extra_scripts =
        pre:pio_hooks.py
-       extra_script.py
        post:merge_firmware_hook.py
+       post:extra_script.py
 
 custom_backend_modules = AC011K Hardware
                          Watchdog


### PR DESCRIPTION
The ota target now runns the pio build twice as a workaround, because otherwise the merge_firmware_hook.py does not run as wanted. This is not optimal, but not as bad as it sounds as well. In the second run it only builds build.cpp again and links.