### PR TITLE
Add `git describe` output to file_basename and build.cpp

### DIFF
--- a/software/pio_hooks.py
+++ b/software/pio_hooks.py
@@ -257,19 +257,19 @@ def main():
     firmware_url = env.GetProjectOption("custom_firmware_url")
     require_firmware_info = env.GetProjectOption("custom_require_firmware_info")
     build_flags = env.GetProjectOption("build_flags")
+    is_release = len(subprocess.run(["git", "tag", "--contains", "HEAD"], check=True, capture_output=True).stdout) > 0
+    is_dirty = len(subprocess.run(["git", "diff"], check=True, capture_output=True).stdout) > 0
+    dirty_suffix = ""
+    git_url = subprocess.run(["git", "config", "--get", "remote.origin.url"], check=True, capture_output=True).stdout.decode("utf-8").strip()
+    git_commit_id = subprocess.run(["git", "rev-parse", "--short=15", "HEAD"], check=True, capture_output=True).stdout.decode("utf-8").strip()
+    branch_name = subprocess.run(["git", "branch", "--show-current"], check=True, capture_output=True).stdout.decode("utf-8").strip()
 
-    process = subprocess.Popen(["git", "branch", "--show-current"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    current_branch, err = process.communicate()
-    if process.wait() != 0:
-        print('Error: Could not get current git branch: {0}'.format(err))
-        sys.exit(1)
+    if is_dirty or not is_release:
+        if branch_name == "master":
+            dirty_suffix = '_' + git_commit_id
+        else:
+            dirty_suffix = '_' + git_commit_id + "_" + branch_name
 
-    process = subprocess.Popen(["git", "describe", "--dirty=-{}-{}".format(str(current_branch.decode("utf-8").strip()), time.strftime('%Y-%m-%d-%H:%M:%S', time.localtime(timestamp)).strip())], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    git_describe, err = process.communicate()
-    if process.wait() != 0:
-        print('Error: Could not get git describe output: {0}'.format(err))
-        sys.exit(1)
-    git_describe = str(git_describe.decode("utf-8").strip())
 
     try:
         oldest_version, version = get_changelog_version(name)
@@ -355,22 +355,26 @@ def main():
         f.write('uint32_t build_timestamp(void);\n')
         f.write('const char *build_timestamp_hex_str(void);\n')
         f.write('const char *build_version_full_str(void);\n')
-        f.write('const char *build_git_describe_str(void);\n')
+        f.write('const char *build_info_str(void);\n')
 
     with open(os.path.join('src', 'build.cpp'), 'w', encoding='utf-8') as f:
         f.write('#include "build.h"\n')
         f.write('uint32_t build_timestamp(void) {{ return {}; }}\n'.format(timestamp))
         f.write('const char *build_timestamp_hex_str(void) {{ return "{:x}"; }}\n'.format(timestamp))
         f.write('const char *build_version_full_str(void) {{ return "{}.{}.{}-{:x}"; }}\n'.format(*version, timestamp))
-        f.write('const char *build_git_describe_str(void) {{ return "{}"; }}\n'.format(git_describe))
+        f.write('const char *build_info_str(void) {{ return "git url: {}, git branch: {}, git commit id: {}"; }}\n'.format(git_url, branch_name, git_commit_id))
+        #f.write('const char *build_info_str(void) {{ return "git url: {}, git branch: {}, git commit id: {}, build flags: {}"; }}\n'.format(git_url, branch_name, git_commit_id, str(re.escape(build_flags))))
+
+    firmware_basename = '{}_firmware{}_{}_{:x}{}'.format(
+        name,
+        "-WITH-WIFI-PASSPHRASE-DO-NOT-DISTRIBUTE_" if not_for_distribution else "",
+        '_'.join(version),
+        timestamp,
+        dirty_suffix,
+    )
 
     with open(os.path.join(env.subst('$BUILD_DIR'), 'firmware_basename'), 'w', encoding='utf-8') as f:
-        if not_for_distribution:
-            #f.write('{}_firmware-WITH-WIFI-PASSPHRASE-DO-NOT-DISTRIBUTE_{}_{:x}'.format(name, '_'.join(version), timestamp))
-            f.write('{}_firmware-WITH-WIFI-PASSPHRASE-DO-NOT-DISTRIBUTE_{}_{:x}_{}'.format(name, '_'.join(version), timestamp, git_describe))
-        else:
-            #f.write('{}_firmware_{}_{:x}'.format(name, '_'.join(version), timestamp, ))
-            f.write('{}_firmware_{}_{:x}_{}'.format(name, '_'.join(version), timestamp, git_describe))
+        f.write(firmware_basename)
 
     # Handle backend modules
     excluded_backend_modules = list(os.listdir('src/modules'))

--- a/software/src/modules/ac011k/ac011k.cpp
+++ b/software/src/modules/ac011k/ac011k.cpp
@@ -789,6 +789,7 @@ void AC011K::pre_setup() {
 }
 
 void AC011K::setup() {
+    logger.printfln("This is BUILD %s.", build_git_describe_str());
     evse.setup_evse();
     evse.update_all_data();
     evse.setup();

--- a/software/src/modules/ac011k/ac011k.cpp
+++ b/software/src/modules/ac011k/ac011k.cpp
@@ -789,7 +789,7 @@ void AC011K::pre_setup() {
 }
 
 void AC011K::setup() {
-    logger.printfln("This is BUILD %s.", build_git_describe_str());
+    logger.printfln("BUILD info: %s.", build_info_str());
     evse.setup_evse();
     evse.update_all_data();
     evse.setup();


### PR DESCRIPTION
- By adding the output of `git describe` we get a clear view on what git commit we are building on. This way investigating error reports even on intermediate builds is more easy.
- This change inserts the following to the filename of the firmware, as well as into the build.cpp to add a log line on boot.

```
warpAC011K_firmware_2_0_11_63e7c626_  
warpAC011K-2.0.8-186-g34455a3d-improve-build-versioning-2023-02-11-17:45:26  
_merged.bin
```
* most recent tag,  _and if there are further commits, the:_
* number of commits thereafter,  _as well as the:_
* git commit hash,  _and if the build is not clean, the:_
* name of the current branch,  _and the current:_
* date time

This addresses #24