### PR TITLE
Fix reset function

### DIFF
--- a/software/src/config.cpp
+++ b/software/src/config.cpp
@@ -113,10 +113,12 @@ struct default_validator {
                 if ((int)x.get(i)->value.tag != slot->variantType)
                     return String(String("[") + i + "] has wrong type");
 
+        size_t i = 0;
         for (const Config &elem : *x.getVal()) {
             String err = Config::apply_visitor(default_validator{}, elem.value);
             if (err != "")
-                return err;
+                return String("[") + i + "] " + err;
+            ++i;
         }
 
         return String("");
@@ -126,8 +128,9 @@ struct default_validator {
     {
         for (const std::pair<String, Config> &elem : *x.getVal()) {
             String err = Config::apply_visitor(default_validator{}, elem.second.value);
+
             if (err != "")
-                return err;
+                return String("[\"") + elem.first.c_str() + "\"] " + err;
         }
 
         return String("");
@@ -371,7 +374,7 @@ struct from_json {
             x.getVal()->push_back(*prototype);
             String inner_error = Config::apply_visitor(from_json{arr[i], force_same_keys, permit_null_updates, false}, x.get(i)->value);
             if (inner_error != "")
-                return String("[") + i + "]" + inner_error;
+                return String("[") + i + "] " + inner_error;
         }
 
         return String("");
@@ -415,7 +418,7 @@ struct from_json {
             if (inner_error != "")
             {
                 if (return_str.length() < 1000)
-                    return_str += String("[\"") + x.getVal()->at(i).first + "\"]" + inner_error + "\n";
+                    return_str += String("[\"") + x.getVal()->at(i).first + "\"] " + inner_error + "\n";
                 else
                     more_errors = true;
             }
@@ -528,7 +531,7 @@ struct from_update {
             x.getVal()->push_back(*prototype);
             String inner_error = Config::apply_visitor(from_update{&arr->elements[i]}, x.get(i)->value);
             if (inner_error != "")
-                return String("[") + i + "]" + inner_error;
+                return String("[") + i + "] " + inner_error;
         }
 
         return String("");
@@ -561,7 +564,7 @@ struct from_update {
 
             String inner_error = Config::apply_visitor(from_update{&obj->elements[obj_idx].second}, x.getVal()->at(i).second.value);
             if (inner_error != "")
-                return String("[\"") + x.getVal()->at(i).first + "\"]" + inner_error;
+                return String("[\"") + x.getVal()->at(i).first + "\"] " + inner_error;
         }
 
         return String("");

--- a/software/src/config.cpp
+++ b/software/src/config.cpp
@@ -406,6 +406,9 @@ struct from_json {
         for (size_t i = 0; i < x.getVal()->size(); ++i) {
             if (!obj.containsKey(x.getVal()->at(i).first))
             {
+                if (!force_same_keys)
+                    continue;
+
                 if (return_str.length() < 1000)
                     return_str += String("JSON object is missing key '") + x.getVal()->at(i).first + "'\n";
                 else
@@ -425,12 +428,14 @@ struct from_json {
 
         }
 
-        for (auto i = obj.begin(); i != obj.end(); i += 1)
-        {
-            if (return_str.length() < 1000)
-                return_str += String("Config has no key '") + i->key().c_str() + "'.\n";
-            else
-                more_errors = true;
+        if (force_same_keys) {
+            for (auto i = obj.begin(); i != obj.end(); i += 1)
+            {
+                if (return_str.length() < 1000)
+                    return_str += String("JSON object has unknown key '") + i->key().c_str() + "'.\n";
+                else
+                    more_errors = true;
+            }
         }
 
         if (return_str.length() > 0)
@@ -1350,7 +1355,7 @@ String ConfigRoot::update_from_file(File &file)
     if (error)
         return String("Failed to read file: ") + String(error.c_str());
 
-    return this->update_from_json(doc.as<JsonVariant>());
+    return this->update_from_json(doc.as<JsonVariant>(), false);
 }
 
 // Intentionally take a non-const char * here:
@@ -1362,7 +1367,7 @@ String ConfigRoot::update_from_cstr(char *c, size_t len)
 
     switch (error.code()) {
         case DeserializationError::Ok:
-            return this->update_from_json(doc.as<JsonVariant>());
+            return this->update_from_json(doc.as<JsonVariant>(), true);
         case DeserializationError::NoMemory:
             return String("Failed to deserialize: JSON payload was longer than expected and possibly contained unknown keys.");
         case DeserializationError::EmptyInput:
@@ -1378,10 +1383,10 @@ String ConfigRoot::update_from_cstr(char *c, size_t len)
     }
 }
 
-String ConfigRoot::update_from_json(JsonVariant root)
+String ConfigRoot::update_from_json(JsonVariant root, bool force_same_keys)
 {
     Config copy = *this;
-    String err = Config::apply_visitor(from_json{root, !this->permit_null_updates, this->permit_null_updates, true}, copy.value);
+    String err = Config::apply_visitor(from_json{root, force_same_keys, this->permit_null_updates, true}, copy.value);
 
     if (err != "")
         return err;

--- a/software/src/config.h
+++ b/software/src/config.h
@@ -810,7 +810,7 @@ public:
     // This allows ArduinoJson to deserialize in zero-copy mode
     String update_from_cstr(char *c, size_t payload_len);
 
-    String update_from_json(JsonVariant root);
+    String update_from_json(JsonVariant root, bool force_same_keys);
 
     String update(const Config::ConfUpdate *val);
 

--- a/software/src/modules/ac011k/ac011evse_v2.cpp
+++ b/software/src/modules/ac011k/ac011evse_v2.cpp
@@ -333,7 +333,7 @@ void EVSEV2::apply_defaults()
 
 void EVSEV2::factory_reset()
 {
-    logger.printfln("EVSE factory reset is not implemented yet.");
+    logger.printfln("AC011K factory reset of the GD chip is not implemented. And probably doesn't have to.");
 }
 
 void EVSEV2::setup()

--- a/software/src/modules/ac011k/ac011k.cpp
+++ b/software/src/modules/ac011k/ac011k.cpp
@@ -764,12 +764,6 @@ bool AC011K::handle_update_chunk(int command, WebServerRequest request, size_t c
 }
 #endif
 
-void AC011K::factory_reset()
-{
-    evse.factory_reset();
-    logger.printfln("AC011K factory reset is not implemented yet.");
-}
-
 void AC011K::update_all_data() {
     evse.update_all_data();
     evse_slot_machine();

--- a/software/src/modules/ac011k/ac011k.h
+++ b/software/src/modules/ac011k/ac011k.h
@@ -128,8 +128,6 @@ public:
     // bool apply_slot_default(uint8_t slot, uint16_t current, bool enabled, bool clear);
     // void apply_defaults();
 
-    void factory_reset();
-
     // bool debug = false;
 
     void log_hex_privcomm_line(byte *data);

--- a/software/src/modules/ac011k/preinit.cpp
+++ b/software/src/modules/ac011k/preinit.cpp
@@ -21,7 +21,8 @@ enum EraseStages {
     deleteNetwork = 1,
     deleteConfig = 2,
     deleteAll = 3,
-    doNothingWithPress = 4
+    doNothingWithPressShort = 4,
+    doNothingWithPressLong = 5,
 };
 
 #include "../ac011k_hardware/ac011k_hardware.h"
@@ -32,14 +33,14 @@ void evse_v2_button_recovery_handler() {
     pinMode(GREEN_LED, OUTPUT);
     pinMode(RED_LED, OUTPUT);
     pinMode(BUTTON, INPUT);
-    digitalWrite(GREEN_LED, HIGH);
-    digitalWrite(RED_LED, HIGH);
+    digitalWrite(GREEN_LED, LED_OFF);
+    digitalWrite(RED_LED, LED_OFF);
 
     EraseStages stage = doNothingNoPress;
     bool oneTimePrint = true;
     bool btn = digitalRead(BUTTON);
 
-    while(btn == LOW && !deadline_elapsed(start + BUTTON_STAGE_OVERTIME)) {
+    while(btn == BUTTON_PRESSED && !deadline_elapsed(start + BUTTON_STAGE_OVERTIME)) {
         btn = digitalRead(BUTTON);
         
         if (deadline_elapsed(start + BUTTON_STAGE_IS_PRESSED) && !deadline_elapsed(start + BUTTON_STAGE_DELETE_NETWORK)) {
@@ -47,9 +48,9 @@ void evse_v2_button_recovery_handler() {
             if (oneTimePrint) {
                 logger.printfln("Button SW3 is pressed. Waiting for release.");
                 oneTimePrint = false;
-                digitalWrite(GREEN_LED, LOW);
+                digitalWrite(GREEN_LED, LED_ON);
             }
-            stage = doNothingWithPress;
+            stage = doNothingWithPressShort;
         }
         if (deadline_elapsed(start + BUTTON_STAGE_DELETE_NETWORK) && !deadline_elapsed(start + BUTTON_STAGE_DELETE_CONFIG)) {
             led_blink(GREEN_LED, 200, 1, 0);
@@ -61,52 +62,54 @@ void evse_v2_button_recovery_handler() {
             stage = deleteConfig;
         }
         if (deadline_elapsed(start + BUTTON_STAGE_DELETE_ALL) && !deadline_elapsed(start + BUTTON_STAGE_OVERTIME)) {
-            digitalWrite(GREEN_LED, HIGH);
+            digitalWrite(GREEN_LED, LED_OFF);
             led_blink(RED_LED, 200, 1, 0);
             stage = deleteAll;
         }
     }
     // check overtime exit from loop
     if (deadline_elapsed(start + BUTTON_STAGE_OVERTIME)){
-        stage = doNothingWithPress;
+        digitalWrite(RED_LED, LED_OFF);
+        stage = doNothingWithPressLong;
     }
 
     switch (stage) {
         case doNothingNoPress:
             break;
-        case doNothingWithPress:
-            // switch securly all leds off
-            digitalWrite(RED_LED, HIGH);
-            digitalWrite(GREEN_LED, HIGH);
-            logger.printfln("Button SW3 is pressed for more than %.3f seconds. Assuming this must be an error. Continuing normal boot.", BUTTON_STAGE_OVERTIME / 1000.0);
+        case doNothingWithPressShort:
+            digitalWrite(RED_LED, LED_OFF);
+            digitalWrite(GREEN_LED, LED_OFF);
+            logger.printfln("Button SW3 was pressed for less than %.1f seconds. Ignoring and continuing normal boot.", BUTTON_STAGE_DELETE_NETWORK / 1000.0);
+            break;
+        case doNothingWithPressLong:
+            logger.printfln("Button SW3 was pressed for more than %.1f seconds. Assuming this must be an error. Continuing normal boot.", BUTTON_STAGE_OVERTIME / 1000.0);
             break;
         case deleteNetwork:
-            logger.printfln("Resetting network configuration and disabling web interface login");
-
+            logger.printfln("Reset requested via button SW3. Resetting network configuration and disabling web interface login.");
             mount_or_format_spiffs();
-            api.restorePersistentConfig("users/config", &users.user_config);
-            users.user_config.get("http_auth_enabled")->updateBool(false);
-            api.writeConfig("users/config", &users.user_config);
-
+            if (api.restorePersistentConfig("users/config", &users.user_config)) {
+                users.user_config.get("http_auth_enabled")->updateBool(false);
+                api.writeConfig("users/config", &users.user_config);
+            }
             api.removeConfig("wifi/sta_config");
             api.removeConfig("wifi/ap_config");
-            logger.printfln("network reset done");
+            logger.printfln("Network reset done.");
             break;
         case deleteConfig:
-            logger.printfln("Removing configuration but keeping charge log.");
+            logger.printfln("Config reset requested via button SW3. Removing configuration but keeping charge log.");
             mount_or_format_spiffs();
             api.removeAllConfig();
-            logger.printfln("config reset done");
+            logger.printfln("Config reset done.");
             break;
         case deleteAll:
-            logger.printfln("Formatting data partition");
+            logger.printfln("Factory reset requested via button SW3. Formatting data partition.");
             LittleFS.begin(false, "/spiffs", 10, "spiffs");
             LittleFS.format();
             LittleFS.end();
-            logger.printfln("factory reset done");
+            logger.printfln("Factory reset done.");
             break;
         default:
-            logger.printfln("Oh oh! unknown state in preinit.cpp: %d", stage);
+            logger.printfln("Oh oh! Unknown state in preinit.cpp: %d", stage);
             break;
     }
 }

--- a/software/src/modules/ac011k/preinit.cpp
+++ b/software/src/modules/ac011k/preinit.cpp
@@ -15,7 +15,7 @@ static const int BUTTON_STAGE_DELETE_CONFIG = 15000;
 static const int BUTTON_STAGE_DELETE_ALL = 20000;
 static const int BUTTON_STAGE_OVERTIME = 25000;
 
-typedef enum EraseStages {
+enum EraseStages {
 
     doNothingNoPress = 0,
     deleteNetwork = 1,
@@ -79,6 +79,7 @@ void evse_v2_button_recovery_handler() {
             digitalWrite(RED_LED, HIGH);
             digitalWrite(GREEN_LED, HIGH);
             logger.printfln("Button SW3 is pressed for more than %.3f seconds. Assuming this must be an error. Continuing normal boot.", BUTTON_STAGE_OVERTIME / 1000.0);
+            break;
         case deleteNetwork:
             logger.printfln("Resetting network configuration and disabling web interface login");
 
@@ -105,7 +106,7 @@ void evse_v2_button_recovery_handler() {
             logger.printfln("factory reset done");
             break;
         default:
-            logger.printfln("Oh oh! unknown state in preinit.cpp: %s", stage);
+            logger.printfln("Oh oh! unknown state in preinit.cpp: %d", stage);
             break;
     }
 }

--- a/software/src/modules/ac011k_hardware/ac011k_hardware.cpp
+++ b/software/src/modules/ac011k_hardware/ac011k_hardware.cpp
@@ -29,7 +29,8 @@ extern TaskScheduler task_scheduler;
 
 #define GREEN_LED 25
 #define BLUE_LED 33
-#define BUTTON T9
+//#define BUTTON T9
+#define BUTTON 32
 
 extern uint32_t uid_numeric;
 extern char uid[7];
@@ -87,11 +88,11 @@ void AC011KHardware::setup()
     blue_led_pin = BLUE_LED;
     button_pin = BUTTON;
 
-    task_scheduler.scheduleWithFixedDelay([](){
-        static bool led_blink_state = false;
-        led_blink_state = !led_blink_state;
-        digitalWrite(BLUE_LED, led_blink_state ? HIGH : LOW);
-    }, 0, 1000);
+    /* task_scheduler.scheduleWithFixedDelay([](){ */
+    /*     static bool led_blink_state = false; */
+    /*     led_blink_state = !led_blink_state; */
+    /*     digitalWrite(BLUE_LED, led_blink_state ? HIGH : LOW); */
+    /* }, 0, 1000); */
 
     api.restorePersistentConfig("ac011k_hardware/config", &config);
     api.restorePersistentConfig("ac011k_hardware/meter", &meter);
@@ -116,18 +117,23 @@ void AC011KHardware::register_urls()
 
 void AC011KHardware::loop()
 {
-    //static bool last_btn_value = false;
-    //static uint32_t last_btn_change = 0;
+    static int last_btn_value = 0;
+    static uint32_t last_btn_change = 0;
 
-    bool btn = touchRead(BUTTON);
-    if (!factory_reset_requested)
-        digitalWrite(GREEN_LED, btn);
+    //int btn = touchRead(BUTTON);
+    bool btn = digitalRead(BUTTON);
+    /* if (!factory_reset_requested) { */
+    /*     //digitalWrite(GREEN_LED, btn); */
+    /*     digitalWrite(BLUE_LED, btn); */
+    /* } */
 
-    // if (btn != last_btn_value) {
-    //     last_btn_change = millis();
-    // }
+    if (last_btn_change == 0) logger.printfln("Button SW3 changed state to %d.", btn);
+    if (btn != last_btn_value) {
+        last_btn_change = millis();
+        logger.printfln("Button SW3 changed state to %d.", btn);
+    }
 
-    //last_btn_value = btn;
+    last_btn_value = btn;
 
     /* if (!btn && deadline_elapsed(last_btn_change + 10000)) { */
     /*     logger.printfln("IO0 button was pressed for 10 seconds. Resetting to factory defaults."); */

--- a/software/src/modules/ac011k_hardware/ac011k_hardware.cpp
+++ b/software/src/modules/ac011k_hardware/ac011k_hardware.cpp
@@ -114,6 +114,7 @@ void AC011KHardware::loop()
 {
     static int last_btn_value = HIGH;
     static uint32_t last_btn_change = 0;
+    static bool first = false;
 
     bool btn = digitalRead(BUTTON);
     if (!factory_reset_requested) {
@@ -123,13 +124,15 @@ void AC011KHardware::loop()
     if (btn != last_btn_value) {
         last_btn_change = millis();
         logger.printfln("Button SW3 changed state to: %s.", (btn == HIGH) ? "high" : "low" );
+        first = true;
     }
 
     last_btn_value = btn;
 
-    if (!btn && deadline_elapsed(last_btn_change + 10000)) {
-        logger.printfln("Button SW3 was pressed for 10 seconds. Resetting to factory defaults.");
-        last_btn_change = millis();
-        factory_reset_requested = true;
+    if (!btn && first && deadline_elapsed(last_btn_change + 10000)) {
+        logger.printfln("Button SW3 was pressed for 10 seconds. But resetting should be done on boot. Please use power off/on or SW1 to restart and press SW3 on boot to reset.");
+        first = false;
+        //logger.printfln("Button SW3 was pressed for 10 seconds. Resetting to factory defaults.");
+        //factory_reset_requested = true;
     }
 }

--- a/software/src/modules/ac011k_hardware/ac011k_hardware.h
+++ b/software/src/modules/ac011k_hardware/ac011k_hardware.h
@@ -25,6 +25,10 @@
 #define GREEN_LED 25
 #define RED_LED 33
 #define BUTTON 32
+#define LED_OFF HIGH
+#define LED_ON LOW
+#define BUTTON_NOT_PRESSED HIGH
+#define BUTTON_PRESSED LOW
 
 class AC011KHardware {
 public:

--- a/software/src/modules/ac011k_hardware/ac011k_hardware.h
+++ b/software/src/modules/ac011k_hardware/ac011k_hardware.h
@@ -22,6 +22,10 @@
 
 #include "config.h"
 
+#define GREEN_LED 25
+#define RED_LED 33
+#define BUTTON 32
+
 class AC011KHardware {
 public:
     AC011KHardware();

--- a/software/src/modules/firmware_update/firmware_update.cpp
+++ b/software/src/modules/firmware_update/firmware_update.cpp
@@ -30,6 +30,7 @@
 #include "tools.h"
 #include "build.h"
 #include "modules.h"
+#include "web_server.h"
 
 #include "./crc32.h"
 #include "./recovery_html.embedded.h"
@@ -38,12 +39,6 @@
 #include <freertos/task.h>
 
 extern const char *DISPLAY_NAME;
-
-extern API api;
-extern EventLog logger;
-
-extern WebServer server;
-extern TaskScheduler task_scheduler;
 
 extern bool firmware_update_allowed;
 extern bool factory_reset_requested;
@@ -86,9 +81,6 @@ void factory_reset()
 #endif
 #if MODULE_EVSE_V2_AVAILABLE()
     evse_v2.factory_reset();
-#endif
-#if MODULE_AC011K_AVAILABLE()
-    ac011k.factory_reset();
 #endif
 
     LittleFS.end();
@@ -390,9 +382,6 @@ void FirmwareUpdate::register_urls()
 #endif
 #if MODULE_EVSE_V2_AVAILABLE()
             evse_v2.factory_reset();
-#endif
-#if MODULE_AC011K_AVAILABLE()
-            ac011k.factory_reset();
 #endif
 
 #if MODULE_USERS_AVAILABLE()


### PR DESCRIPTION
This change implements 3 reset stages.

0. Resetting network configuration and disabling web interface login
1. Removing configuration but keeping charge log.
2. Format data partition. (This also removes tracked charges and the username file)

The reset is initiated by pressing button SW3 during boot.  
The stage is selected by the duration of holding the button down.

If you **press and hold SW3 on boot**, the **green LED** will be on for the **first 10 seconds**. If you release the button within this time, **nothing** will be reset and the boot will continue normally. If the button is **still pressed**, the **green LED** will start **flashing** and if SW3 is released within the **next 5 seconds** **_stage 0_ will be initiated**. The **next 5 seconds** both, the **green and the red LED will be flashing** and if released in this period, **_stage 1_ will be entered**. If still pressed, **only the red LED will flash for another 5 seconds** and if released now, **_stage 2_ will be executed**.   
If SW3 is still pressed after this, finally a normal boot will happen without resetting anything.