### PR TITLE
Support AC011K-AE-25-STL and AC011K-AU-25-STL

### DIFF
--- a/software/src/modules/ac011k/ac011k.cpp
+++ b/software/src/modules/ac011k/ac011k.cpp
@@ -1226,6 +1226,8 @@ void AC011K::loop()
                     evse.initialized = (
                             (evse.evse_hardware_configuration.get("Hardware")->asString().compareTo("AC011K-AU-25") == 0) 
                             || (evse.evse_hardware_configuration.get("Hardware")->asString().compareTo("AC011K-AE-25") == 0)
+                            || (evse.evse_hardware_configuration.get("Hardware")->asString().compareTo("AC011K-AU-25-STL") == 0)
+                            || (evse.evse_hardware_configuration.get("Hardware")->asString().compareTo("AC011K-AE-25-STL") == 0)
                         )
                         && (   
                             (   


### PR DESCRIPTION
This change just marks AC011K-AE-25-STL and AC011K-AU-25-STL hardware signatures as supported.

Confirmed as working in #53.